### PR TITLE
Implemented a "All field declarations optional"-option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Options:
    -m,  --mutable          Swift: All object fields are mutable (var instead of let)
    -pt, --publictypes      Swift: Make type declarations public instead of internal
    -pf, --publicfields     Swift: Make field declarations public instead of internal
+   -op, --optional         Swift: Make all field declarations optional
 ```
 
 ### To create a Swift data model:

--- a/Sources/ReverseJson/main.swift
+++ b/Sources/ReverseJson/main.swift
@@ -24,6 +24,7 @@ func usage() -> String {
         "   -m,  --mutable          Swift: All object fields are mutable (var instead of let)",
         "   -pt, --publictypes      Swift: Make type declarations public instead of internal",
         "   -pf, --publicfields     Swift: Make field declarations public instead of internal",
+        "   -op, --optional         Swift: Make all field declarations optional",
     ].joinWithSeparator("\n")
 }
 
@@ -56,7 +57,13 @@ func main(args: [String]) -> ProgramResult {
     }
     let rootType: ModelParser.FieldType
     do {
-        rootType = try ModelParser().decode(model)
+        let rootTypeTmp = try ModelParser().decode(model)
+        let makeAllFieldDeclarationsOptional = remainingArgs.contains("-op") || remainingArgs.contains("--optional")
+        if makeAllFieldDeclarationsOptional {
+            rootType = ModelParser.transformAllFieldsToOptional(rootTypeTmp)
+        } else {
+            rootType = rootTypeTmp
+        }
     } catch {
         return .Failure("Could convert json to model: \(error)")
     }


### PR DESCRIPTION
I'm using it to parse the results of Microsofts Computer Vision API, where nearly all fields inside the JSON are optional. It's easier (and less error-prone) to have an option that I can just turn on while generating the swift-code to generate optional fields, instead of modifying their example-json to achieve an inferred optional-attribute by ReverseJson.
